### PR TITLE
Specify angular v1.5 in bower.json

### DIFF
--- a/express-angular/public/bower.json
+++ b/express-angular/public/bower.json
@@ -18,6 +18,6 @@
     "bootstrap": "~3.2.0",
     "lodash": "^2.4.1",
     "jquery": "~2.1.1",
-    "angular": "*"
+    "angular": "~1.5.x"
   }
 }

--- a/hapi-angular/public/bower.json
+++ b/hapi-angular/public/bower.json
@@ -18,6 +18,6 @@
     "bootstrap": "~3.2.0",
     "lodash": "^2.4.1",
     "jquery": "~2.1.1",
-    "angular": "*"
+    "angular": "~1.5.x"
   }
 }


### PR DESCRIPTION
- `bower.json` specifies `"angular": "*"` which causes `bower` to download  `angular@1.6.x` which causes front end to not render at all. 
- This fix specifies `angular@1.5.x` in `bower.json` so the front end renders correctly and everybody can learn from this example 😸 